### PR TITLE
fix: observe line length limits

### DIFF
--- a/rf96/RF.f90
+++ b/rf96/RF.f90
@@ -1,5 +1,7 @@
 ! input observer RF, velocity model and return calculated RF
-Subroutine RFcalc_nonoise(voro,mtype,fs,gauss_a,water_c,angle,time_shift,ndatar,v60,npt,time,wdata) bind(c,name="rfcalc_nonoise")
+Subroutine RFcalc_nonoise(voro,mtype,fs,gauss_a,water_c,angle,&
+        time_shift,ndatar,v60,npt,time,wdata)&
+        bind(c,name="rfcalc_nonoise")
 !F2PY INTENT(OUT) :: wdata
 !F2PY INTENT(OUT) :: time
 !F2PY INTENT(IN) :: voro
@@ -124,7 +126,9 @@ enddo
 return
 end
 ! input observer RF, velocity model and return calculated RF
-Subroutine RFcalc_noise(voro,mtype,sn,fs,gauss_a,water_c,angle,time_shift,ndatar,v60,seed,npt,time,wdata) bind(c,name="rfcalc_noise")
+Subroutine RFcalc_noise(voro,mtype,sn,fs,gauss_a,water_c,angle,&
+        time_shift,ndatar,v60,seed,npt,time,wdata)&
+        bind(c,name="rfcalc_noise")
 !Subroutine RFcalc_noise(voro,npt,ndatar) bind(c,name="rfcalc_noise")
 !F2PY INTENT(OUT) :: wdata
 !F2PY INTENT(OUT) :: time


### PR DESCRIPTION
Gfortran prior to version 14 imposes a line length limit that leads to a compile time error if lines in the source code are longer than 72 characters. This pull request updates RF90.f90 so that it can be compiled with gfortran-13 without the need for compiler flags changing the default line length limit.